### PR TITLE
Use nested Text where possible.

### DIFF
--- a/src/ui/components/LineupTitle2.js
+++ b/src/ui/components/LineupTitle2.js
@@ -130,14 +130,14 @@ export default class LineupTitle2 extends Component<Props, State> {
             </Text>;
         }
 
-        return count > 0 && <View style={[styles.medalsContainer, {marginLeft: 4}]} key={icon}>
+        return count > 0 && <Text key={icon}>
             {displayDot.next().value && <Text style={[styles.smallText, {color, marginHorizontal: 6}]}>• </Text>}
             <Icon name={icon} size={iconSize} color={color}/>
             <Text style={[styles.smallText, {marginLeft: 4, color,
                 alignSelf: 'flex-end',
                 // backgroundColor: 'red',
-            }]}>{count}</Text>
-        </View>;
+            }]}>{' '}{count}{' '}</Text>
+        </Text>;
     }
 }
 


### PR DESCRIPTION
Quand l'application n'est pas en debug et qu'on a ça en view:
```
<Text style={STYLES.SECTION_TITLE}>
                                    {lineup.name}
                                    {' '}

                                    <View><Text>vt</Text></View>
                                    <Text><View>tv</View></Text>
                                    {
                                        this.getMedals(lineup)
                                    }

                                </Text>
```

Ni vt ni tv sont affichés. Je ne sais pas pourquoi, du coup j'utilise du nested text quand c'est possible. Maintenant ça fonctionne à nouveau